### PR TITLE
Add TryGet for spritesheet

### DIFF
--- a/SpriteSheet.cs
+++ b/SpriteSheet.cs
@@ -1,33 +1,46 @@
-using System.Collections.Generic;
+namespace TexturePackerLoader;
 
-namespace TexturePackerLoader
+public class SpriteSheet
 {
-    public class SpriteSheet
+    private readonly IDictionary<string, SpriteFrame> spriteList;
+
+    public SpriteSheet()
     {
-        private readonly IDictionary<string, SpriteFrame> spriteList;
-
-        public SpriteSheet()
-        {
-            spriteList = new Dictionary<string, SpriteFrame>();
-        }
-
-        public void Add(string name, SpriteFrame sprite)
-        {
-            spriteList.Add(name, sprite);
-        }
-
-        public void Add(SpriteSheet otherSheet)
-        {
-            foreach (var sprite in otherSheet.spriteList)
-            {
-                spriteList.Add(sprite);
-            }
-        }
-
-        public SpriteFrame Sprite(string sprite)
-        {
-            return spriteList[sprite];
-        }
-
+        spriteList = new Dictionary<string, SpriteFrame>();
     }
+
+    public void Add(string name, SpriteFrame sprite)
+    {
+        spriteList.Add(name, sprite);
+    }
+
+    public void Add(SpriteSheet otherSheet)
+    {
+        foreach (var sprite in otherSheet.spriteList)
+        {
+            spriteList.Add(sprite);
+        }
+    }
+
+    public SpriteFrame Sprite(string sprite)
+    {
+        return spriteList[sprite];
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a <see cref="SpriteFrame"/> from the sprite sheet by name.
+    /// </summary>
+    /// <param name="name">The name of the sprite to retrieve.</param>
+    /// <returns>
+    /// The <see cref="SpriteFrame"/> corresponding to the given name if it exists;
+    /// otherwise, <c>null</c>. This method does not throw exceptions if the sprite is missing.
+    /// </returns>
+    public SpriteFrame? TryGetSprite(string sprite)
+    {
+        if (spriteList.TryGetValue(sprite, out var frame))
+            return frame;
+
+        return null;
+    }
+
 }

--- a/TexturePackerLoader.csproj
+++ b/TexturePackerLoader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Added Try Get option for SpriteSheet, to avoid exceptions. For myself I find the exceptions getting thrown quite annoying and it was causing performance issues when wrapping try/catch as a workaround. Since I have thousands of sprites and multiple spritesheets, sometimes a quick lookup by sprite name is better than mapping every sprite to a spritesheet.